### PR TITLE
Use the FTLOGIN variable to get the users login

### DIFF
--- a/header.el
+++ b/header.el
@@ -22,7 +22,7 @@
 ;    By: login____ <mail_______@student.42.fr>      +#+  +:+       +#+         ;
 ;                                                 +#+#+#+#+#+   +#+            ;
 ;    Created: yyyy/mm/dd 15:27:11 by login____         #+#    #+#              ;
-;    Updated: 2016/11/08 22:16:21 by Crabe            ###   ########.fr        ;
+;    Updated: 2017/12/01 15:17:32 by rhallste         ###   ########.fr        ;
 ;                                                                              ;
 ;******************************************************************************;
 
@@ -32,9 +32,12 @@
 (setq write-file-hooks (cons 'header-update write-file-hooks))
 
 
-(set 'user-login "suvitiel")
-
-
+(set 'user-login (let ((login (getenv "FTLOGIN")))
+				   (if (string= login nil)
+					   "undefined"
+					 login)
+				   )
+	 )
 
 
 (set 'user-mail (let ((mail (getenv "MAIL")))


### PR DESCRIPTION
This allows you to use the header correctly on non-42 computers as well.
Currently, it defaults to `suvitiel`. This allows people to set the `FTLOGIN` variable to their own login.